### PR TITLE
fix callback order

### DIFF
--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -257,14 +257,12 @@ export class KubeApi<T extends UnstructuredList> {
     let { items } = response as unknown as UnstructuredList;
     const stops: Array<() => void> = [];
 
-    const handleEvent = (event: WatchEvent) => {
+    const handleEvent = (event: Readonly<WatchEvent>) => {
       if (event.type === 'PING') {
         return;
       }
 
       informerLog('INFORMER', event);
-
-      onEvent?.(event);
 
       const name = event.object.metadata.name;
       const namespace = event.object.metadata.namespace;
@@ -314,6 +312,7 @@ export class KubeApi<T extends UnstructuredList> {
         ...response,
         items,
       });
+      onEvent?.(event);
     };
 
     stops.push(this.watchBySdk(response, handleEvent));


### PR DESCRIPTION
With the live provider, when a k8s watch event fired, the expected behavior is:

1. Update list-watch items according to event type, e.g., ADDED/MODIFIED/DELETED.
2. Set updated items into the global store, via the onResponse callback.
3. Publish the event to the live provider, and notify Apps to re-query from the global store, via the onEvent callback.

So we need to change the order of callbacks to make sure onEvent fires after onResponse.