### PR TITLE
fix: Fix the logic of filters contain/in relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ lib
 
 # misc
 .DS_Store
+.idea
 .env.local
 .env.development.local
 .env.test.local

--- a/__tests__/utils/filter-data.spec.ts
+++ b/__tests__/utils/filter-data.spec.ts
@@ -1,5 +1,6 @@
-import { filterData } from '../../src/utils/filter-data';
+import { filterData, evaluateFilter } from '../../src/utils/filter-data';
 import { CrudFilters } from '@refinedev/core';
+import { Unstructured } from '../../lib';
 
 describe('filterData function', () => {
   const unstructuredData = [
@@ -93,3 +94,139 @@ describe('filterData function', () => {
     expect(filteredData).toEqual(unstructuredData);
   });
 });
+
+describe('evaluateFilter function', () => {
+  const mockItem = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'test-pod',
+      namespace: 'default',
+    },
+    spec: {
+      total: 10,
+      labels: ['label-1', 'label-2'],
+      description: null,
+    }
+  } as Unstructured;
+
+  test('handles "eq" operator', () => {
+    const result = evaluateFilter(mockItem, 'kind', 'eq', 'Pod');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "ne" operator', () => {
+    const result = evaluateFilter(mockItem, 'kind', 'ne', 'Service');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "lt" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'lt', 11);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "gt" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'gt', 9);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "lte" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'lte', 10);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "gte" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'gte', 10);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "in" operator', () => {
+    expect(evaluateFilter(mockItem, 'spec.labels', 'in', ['label-1', 'label-2'])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.total', 'in', ['label-1', 'label-2'])).toBeFalsy();
+  });
+
+  test('handles "nin" operator', () => {
+    expect(evaluateFilter(mockItem, 'spec.labels', 'nin', ['label-3', 'label-4'])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.total', 'nin', ['label-3', 'label-4'])).toBeFalsy();
+  });
+
+  test('handles "contains" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'contains', 'test');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "ncontains" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'ncontains', 'prod');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "containss" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'containss', 'TEST');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "ncontainss" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'ncontainss', 'PROD');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "between" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'between', [1, 11]);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nbetween" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'nbetween', [2, 9]);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "null" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.description', 'null', null);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nnull" operator', () => {
+    const result = evaluateFilter(mockItem, 'spec.total', 'nnull', null);
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "startswith" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'startswith', 'test');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nstartswith" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'nstartswith', 'prod');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "startswiths" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'startswiths', 'TEST');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nstartswiths" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'nstartswiths', 'PROD');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "endswith" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'endswith', 'pod');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nendswith" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'nendswith', 'service');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "endswiths" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'endswiths', 'POD');
+    expect(result).toBeTruthy();
+  });
+
+  test('handles "nendswiths" operator', () => {
+    const result = evaluateFilter(mockItem, 'metadata.name', 'nendswiths', 'SERVICE');
+    expect(result).toBeTruthy();
+  });
+})

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@commitlint/config-conventional": "^17.7.0",
     "@kubernetes/client-node": "^0.18.1",
     "@refinedev/core": "^4.44.4",
+    "@types/jest": "^29",
     "@types/lodash": "^4.14.149",
     "@types/node": "^18.16.2",
     "@typescript-eslint/eslint-plugin": "^6.6.0",

--- a/src/utils/filter-data.ts
+++ b/src/utils/filter-data.ts
@@ -36,10 +36,10 @@ export const filterData = (
   });
 };
 
-function evaluateFilter(
+export function evaluateFilter(
   item: Unstructured,
   field: string,
-  operator: CrudOperators,
+  operator: Exclude<CrudOperators, 'or' | 'and'>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any
 ): boolean {
@@ -58,18 +58,26 @@ function evaluateFilter(
       return fieldValue <= value;
     case 'gte':
       return fieldValue >= value;
-    case 'in':
-      return value.includes(fieldValue);
-    case 'nin':
-      return !value.includes(fieldValue);
+    case 'in': {
+      if (!Array.isArray(fieldValue) || !Array.isArray(value)) {
+        return false;
+      }
+      return value.some(item => _.includes(fieldValue, item));
+    }
+    case 'nin': {
+      if (!Array.isArray(fieldValue) || !Array.isArray(value)) {
+        return false;
+      }
+      return value.every(item => !_.includes(fieldValue, item));
+    }
     case 'contains':
-      return fieldValue.includes(value);
+      return _.includes(fieldValue, value);
     case 'ncontains':
-      return !fieldValue.includes(value);
+      return !_.includes(fieldValue, value);
     case 'containss':
-      return fieldValue.toLowerCase().includes(value.toLowerCase());
+      return _.includes(fieldValue.toLowerCase(), value.toLowerCase());
     case 'ncontainss':
-      return !fieldValue.toLowerCase().includes(value.toLowerCase());
+      return !_.includes(fieldValue.toLowerCase(), value.toLowerCase());
     case 'between':
       return value[0] <= fieldValue && fieldValue <= value[1];
     case 'nbetween':
@@ -94,7 +102,5 @@ function evaluateFilter(
       return fieldValue.toLowerCase().endsWith(value.toLowerCase());
     case 'nendswiths':
       return !fieldValue.toLowerCase().endsWith(value.toLowerCase());
-    default:
-      return true;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,6 +1073,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29":
+  version "29.5.5"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.5.tgz#727204e06228fe24373df9bae76b90f3e8236a2a"
+  integrity sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/js-yaml@^4.0.1":
   version "4.0.6"
   resolved "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.6.tgz#4b3afd5158b8749095b1f096967b6d0f838d862f"
@@ -2178,7 +2186,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -3944,7 +3952,7 @@ prettier@^2.5.0:
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==


### PR DESCRIPTION
## Content

In previous implementations, the in and contains implementations were buggy and could not handle data of array type.

The include function based on lodash and the filtering modeled on prisma implements the in and contains relationship