### PR TITLE
fix: Fix filter result error when field value is non-array

### DIFF
--- a/__tests__/utils/filter-data.spec.ts
+++ b/__tests__/utils/filter-data.spec.ts
@@ -107,6 +107,7 @@ describe('evaluateFilter function', () => {
       total: 10,
       labels: ['label-1', 'label-2'],
       description: null,
+      type: 'type-1'
     }
   } as Unstructured;
 
@@ -143,11 +144,19 @@ describe('evaluateFilter function', () => {
   test('handles "in" operator', () => {
     expect(evaluateFilter(mockItem, 'spec.labels', 'in', ['label-1', 'label-2'])).toBeTruthy();
     expect(evaluateFilter(mockItem, 'spec.total', 'in', ['label-1', 'label-2'])).toBeFalsy();
+    expect(evaluateFilter(mockItem, 'spec.total', 'in', [10, 20])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'in', ['type-1', 'type-2'])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'in', ['type-3', 'type-4'])).toBeFalsy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'in', 'type-1')).toBeFalsy();
   });
 
   test('handles "nin" operator', () => {
     expect(evaluateFilter(mockItem, 'spec.labels', 'nin', ['label-3', 'label-4'])).toBeTruthy();
-    expect(evaluateFilter(mockItem, 'spec.total', 'nin', ['label-3', 'label-4'])).toBeFalsy();
+    expect(evaluateFilter(mockItem, 'spec.total', 'nin', ['label-3', 'label-4'])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.total', 'nin', [10, 20])).toBeFalsy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'nin', ['type-1', 'type-2'])).toBeFalsy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'nin', ['type-3', 'type-4'])).toBeTruthy();
+    expect(evaluateFilter(mockItem, 'spec.type', 'in', 'type-1')).toBeFalsy();
   });
 
   test('handles "contains" operator', () => {

--- a/src/utils/filter-data.ts
+++ b/src/utils/filter-data.ts
@@ -59,16 +59,26 @@ export function evaluateFilter(
     case 'gte':
       return fieldValue >= value;
     case 'in': {
-      if (!Array.isArray(fieldValue) || !Array.isArray(value)) {
+      if (!Array.isArray(value)) {
         return false;
       }
-      return value.some(item => _.includes(fieldValue, item));
+      return value.some(item => {
+        if (Array.isArray(fieldValue)) {
+          return _.includes(fieldValue, item);
+        }
+        return item === fieldValue
+      });
     }
     case 'nin': {
-      if (!Array.isArray(fieldValue) || !Array.isArray(value)) {
+      if (!Array.isArray(value)) {
         return false;
       }
-      return value.every(item => !_.includes(fieldValue, item));
+      return value.every(item => {
+        if (Array.isArray(fieldValue)) {
+          return !_.includes(fieldValue, item);
+        }
+        return item !== fieldValue
+      });
     }
     case 'contains':
       return _.includes(fieldValue, value);


### PR DESCRIPTION
## Description

#14 

This fix brings another problem, the in/contains judgment logic is skipped when the value of field value is of type non-array.