### PR TITLE
support use meta.k8sResource to override resource name

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -6,7 +6,7 @@ export function getObjectConstructor(resource: string, meta?: MetaQuery) {
   return meta?.resourceBasePath
     ? {
         resourceBasePath: meta?.resourceBasePath,
-        resource,
+        resource: meta?.k8sResource || resource,
         namespace: meta.namespace,
       }
     : {
@@ -26,7 +26,7 @@ export class GlobalStore {
   private _apiUrl = '';
   private watchWsApiUrl?: string;
   prefix?: string;
-  fieldManager?: string
+  fieldManager?: string;
 
   private store = new Map<string, UnstructuredList>();
   private subscribers = new Map<string, ((data: WatchEvent) => void)[]>();
@@ -104,6 +104,6 @@ export class GlobalStore {
     this._apiUrl = apiUrl;
     this.watchWsApiUrl = watchWsApiUrl;
     this.prefix = prefix;
-    this.fieldManager = fieldManager
+    this.fieldManager = fieldManager;
   }
 }


### PR DESCRIPTION
In k8s, we may have resources like this:

- `/api/v1/pods`
- `/apis/metrics.k8s.io/v1beta1/pods`

Currently, we are using refine's `resource` as the last part of the URL. Since `resource` is one of the most essential concepts in Refine, we'd better let these resources use different names in Refine. Then user can define `k8sResource` in the meta to let our API provider know how to construct an object.

For example:

```ts
{
  resource: 'pods',
},
{
  resource: 'podMetrics',
  meta: {
    k8sResource: 'pods'
  }
}
```