### PR TITLE
feat(global store): implement golbal store destory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "tsup --watch",
+    "prepublish": "tsup",
     "build": "tsup",
     "lint": "eslint src --ext .ts --quiet",
     "typings": "tsc",

--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -8,7 +8,7 @@ import {
   CreateResponse,
   MetaQuery,
   UpdateResponse,
-  DeleteOneResponse
+  DeleteOneResponse,
 } from '@refinedev/core';
 import { KubeSdk, Unstructured } from '../kube-api';
 import { filterData } from '../utils/filter-data';
@@ -46,8 +46,8 @@ export const dataProvider = (
         item.metadata.name === name && item.metadata.namespace === namespace
     );
     if (!data) {
-      console.error(`resource: ${resource} not include id: ${id}`)
-      return { data: null as unknown as TData }
+      console.error(`resource: ${resource} not include id: ${id}`);
+      return { data: null as unknown as TData };
     }
     return {
       data: {
@@ -87,27 +87,35 @@ export const dataProvider = (
       };
     },
 
-    getMany: async<TData extends BaseRecord = BaseRecord, TVariables = unknown> (params: {
+    getMany: async <
+      TData extends BaseRecord = BaseRecord,
+      TVariables = unknown
+    >(params: {
       resource: string;
       ids: BaseKey[];
       variables?: TVariables | undefined;
       meta?: MetaQuery | undefined;
       metaData?: MetaQuery | undefined;
     }): Promise<GetManyResponse<TData>> => {
-      const { ids, ...rest } = params
+      const { ids, ...rest } = params;
       const data = await Promise.all(
         ids.map(id => getOne({ id, ...rest }).then(v => v.data))
       );
 
       return {
-        data: data  as unknown as TData[],
+        data: data as unknown as TData[],
       };
     },
 
-    create: async<TData extends BaseRecord = BaseRecord> ({ variables, meta }:Parameters<DataProvider['create']>['0']): Promise<CreateResponse<TData>> => {
+    create: async <TData extends BaseRecord = BaseRecord>({
+      variables,
+      meta,
+    }: Parameters<DataProvider['create']>['0']): Promise<
+      CreateResponse<TData>
+    > => {
       const sdk = new KubeSdk({
         basePath: globalStore.apiUrl,
-        fieldManager: globalStore.fieldManager
+        fieldManager: globalStore.fieldManager,
       });
 
       const data = await sdk.applyYaml([
@@ -123,10 +131,15 @@ export const dataProvider = (
       };
     },
 
-    update: async<TData extends BaseRecord = BaseRecord> ({ variables, meta }:Parameters<DataProvider['update']>['0']): Promise<UpdateResponse<TData>> => {
+    update: async <TData extends BaseRecord = BaseRecord>({
+      variables,
+      meta,
+    }: Parameters<DataProvider['update']>['0']): Promise<
+      UpdateResponse<TData>
+    > => {
       const sdk = new KubeSdk({
         basePath: globalStore.apiUrl,
-        fieldManager: globalStore.fieldManager
+        fieldManager: globalStore.fieldManager,
       });
       const params = [
         {
@@ -134,8 +147,12 @@ export const dataProvider = (
           apiVersion: getApiVersion(meta?.resourceBasePath),
           kind: meta?.kind,
         },
-      ]
-      const data = await sdk.applyYaml(params, meta?.strategy, meta?.replacePaths);
+      ];
+      const data = await sdk.applyYaml(
+        params,
+        meta?.strategy,
+        meta?.replacePaths
+      );
 
       return {
         data: data[0] as unknown as TData,
@@ -144,10 +161,17 @@ export const dataProvider = (
 
     getOne,
 
-    deleteOne:  async<TData extends BaseRecord = BaseRecord> ({ resource, id, meta, ...rest }:Parameters<DataProvider['deleteOne']>['0']): Promise<DeleteOneResponse<TData>> => {
+    deleteOne: async <TData extends BaseRecord = BaseRecord>({
+      resource,
+      id,
+      meta,
+      ...rest
+    }: Parameters<DataProvider['deleteOne']>['0']): Promise<
+      DeleteOneResponse<TData>
+    > => {
       const sdk = new KubeSdk({
         basePath: globalStore.apiUrl,
-        fieldManager: globalStore.fieldManager
+        fieldManager: globalStore.fieldManager,
       });
 
       const { data: current } = await getOne({ id, resource, meta, ...rest });

--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -386,7 +386,6 @@ export class KubeApi<T extends UnstructuredList> {
         stops.push(this.watchByHttp(url, response, handleEvent, retry));
       }
     }
-
     return () => {
       stops.forEach(stop => stop());
     };
@@ -433,7 +432,7 @@ export class KubeApi<T extends UnstructuredList> {
     let shouldCloseAfterConnected = false;
     let stopWatch: () => void = () => {
       if (socket.readyState === socket.OPEN) {
-        socket.close(3001, 'DOVETAIL_MANUAL_CLOSE');
+        socket.close(3001, 'KUBEAPI_MANUAL_CLOSE');
       } else {
         shouldCloseAfterConnected = true;
       }
@@ -445,7 +444,7 @@ export class KubeApi<T extends UnstructuredList> {
 
     socket.addEventListener('open', () => {
       if (shouldCloseAfterConnected) {
-        socket.close(3001, 'DOVETAIL_MANUAL_CLOSE');
+        socket.close(3001, 'KUBEAPI_MANUAL_CLOSE');
         return;
       }
       heartbeat(socket);
@@ -459,7 +458,7 @@ export class KubeApi<T extends UnstructuredList> {
     socket.addEventListener('close', evt => {
       clearTimeout((socket as ExtendedWebsocketClient).pingTimeout);
 
-      if (evt.reason === 'DOVETAIL_MANUAL_CLOSE') {
+      if (evt.reason === 'KUBEAPI_MANUAL_CLOSE') {
         return;
       }
 
@@ -661,11 +660,7 @@ export class KubeSdk {
       }
 
       const response = exist
-        ? await this.patch(
-            spec,
-            strategy,
-            replacePaths?.[index]
-          )
+        ? await this.patch(spec, strategy, replacePaths?.[index])
         : await this.create(spec);
 
       if (exist) {

--- a/src/utils/filter-data.ts
+++ b/src/utils/filter-data.ts
@@ -21,7 +21,7 @@ function deepFilter(item: Unstructured, filter: CrudFilter): boolean {
 
 export const filterData = (
   filters: CrudFilters,
-  data: Unstructured[],
+  data: Unstructured[]
 ): Unstructured[] => {
   if (!filters || filters.length === 0) {
     return data;
@@ -35,7 +35,7 @@ export function evaluateFilter(
   field: string,
   operator: Exclude<CrudOperators, 'or' | 'and'>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any,
+  value: any
 ): boolean {
   if (!_.has(item, field)) {
     return false;

--- a/src/utils/paginate-data.ts
+++ b/src/utils/paginate-data.ts
@@ -7,10 +7,8 @@ export const paginateData = (
 ): Unstructured[] => {
   const { current = 1, pageSize = 20, mode } = pagination ?? {};
   if (mode !== 'client') {
-    console.warn(
-      'k8s no support server paginateData'
-    );
-    return data
+    console.warn('k8s no support server paginateData');
+    return data;
   }
   let start = 0;
   let end = data.length;


### PR DESCRIPTION
We have exposed the init method in the Global store to enable the ability to reinitialize the Global store externally. However, the init implementation only cleans up the Map, and does not manually close the watch on the k8s resource.