### PR TITLE
fix(kube-api): add 'forceApply' parameter to kube-api

### DIFF
--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -118,13 +118,15 @@ export const dataProvider = (
         fieldManager: globalStore.fieldManager,
       });
 
-      const data = await sdk.applyYaml([
+      const data = await sdk.applyYaml({
+        specs: [
         {
           ...(variables as unknown as Unstructured),
           apiVersion: getApiVersion(meta?.resourceBasePath),
           kind: meta?.kind,
-        },
-      ]);
+        }], 
+        forceApply:  meta?.forceApply ?? false
+      });
 
       return {
         data: data[0] as unknown as TData,
@@ -148,11 +150,12 @@ export const dataProvider = (
           kind: meta?.kind,
         },
       ];
-      const data = await sdk.applyYaml(
-        params,
-        meta?.strategy,
-        meta?.replacePaths
-      );
+      const data = await sdk.applyYaml({
+        specs: params,
+        strategy: meta?.strategy,
+        replacePaths: meta?.replacePaths,
+        forceApply: meta?.forceApply ?? true,
+      });
 
       return {
         data: data[0] as unknown as TData,


### PR DESCRIPTION
In the original implementation, we would call the put and patch api in applyYaml to get whether the current resource exists or not, but at the time we assumed that all applyYaml's carried the '--force' parameter.
However, when two resources with the same name are placed by different users, the latter will be incorrectly called by the patch api and override the earlier.
In this MR, we have added the forceApply parameter and set it to false when calling create.When it's not forceApply and the resource exists,  throw an error.