### PR TITLE
fix: fix paginate

### DIFF
--- a/__tests__/utils/paginate-data.spec.ts
+++ b/__tests__/utils/paginate-data.spec.ts
@@ -18,6 +18,26 @@ describe('paginateData function', () => {
       kind: 'Pod',
       metadata: { name: 'Pod C' },
     },
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'Pod C' },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'Pod C' },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'Pod C' },
+    },
+    {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'Pod C' },
+    },
   ];
 
   it('should paginate data in client mode with default settings', () => {
@@ -27,7 +47,7 @@ describe('paginateData function', () => {
     const expectedPaginatedData = unstructuredData;
     expect(paginatedData).toEqual(expectedPaginatedData);
     expect(console.warn).toHaveBeenCalledWith(
-      'k8s no support server paginateData'
+      'Skip simulated paging.'
     );
   });
 
@@ -38,21 +58,29 @@ describe('paginateData function', () => {
     const expectedPaginatedData = unstructuredData
     expect(paginatedData).toEqual(expectedPaginatedData);
     expect(console.warn).toHaveBeenCalledWith(
-      'k8s no support server paginateData'
+      'Skip simulated paging.'
     );
   });
 
-  it('should change to client mode if server mode is specified', () => {
-    const pagination = { mode: 'server' };
+  it('should paginate data if server mode is specified', () => {
+    const pagination = { mode: 'server',  current: 2, pageSize: 2, };
     console.warn = jest.fn(); // mock error
     const paginatedData = paginateData(
       pagination as Pagination,
       unstructuredData
     );
-    const expectedPaginatedData = unstructuredData.slice(0, 10);
+    const expectedPaginatedData = unstructuredData.slice(2, 4);
     expect(paginatedData).toEqual(expectedPaginatedData);
-    expect(console.warn).toHaveBeenCalledWith(
-      'k8s no support server paginateData'
+  });
+
+  it('should do nothing if client mode is specified', () => {
+    const pagination = { mode: 'client' };
+    console.warn = jest.fn(); // mock error
+    const paginatedData = paginateData(
+      pagination as Pagination,
+      unstructuredData
     );
+    const expectedPaginatedData = unstructuredData;
+    expect(paginatedData).toEqual(expectedPaginatedData);
   });
 });

--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -73,6 +73,7 @@ export const dataProvider = (
       if (sorters) {
         items = sortData(sorters, items);
       }
+      const _total = items.length
 
       if (pagination) {
         items = paginateData(pagination, items);
@@ -83,7 +84,7 @@ export const dataProvider = (
           ...item,
           id: getId(item),
         })),
-        total: items.length,
+        total: _total,
       };
     },
 

--- a/src/utils/paginate-data.ts
+++ b/src/utils/paginate-data.ts
@@ -6,8 +6,8 @@ export const paginateData = (
   data: Unstructured[]
 ): Unstructured[] => {
   const { current = 1, pageSize = 20, mode } = pagination ?? {};
-  if (mode !== 'client') {
-    console.warn('k8s no support server paginateData');
+  if (mode !== 'server') {
+    console.warn('Skip simulated paging.');
     return data;
   }
   let start = 0;


### PR DESCRIPTION
In refine, if pagination mode is client side, the getList method of dataprovider will not be called in setCurrent, because it is realized in the client side, so we should change the original judgment to simulate server mode pagination.