### PR TITLE
feat(kube-api): add createyaml

### DIFF
--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -119,7 +119,7 @@ export const dataProvider = (
         fieldManager: globalStore.fieldManager,
       });
 
-      const data = await sdk.applyYaml([
+      const data = await sdk.createyYaml([
         {
           ...(variables as unknown as Unstructured),
           apiVersion: getApiVersion(meta?.resourceBasePath),


### PR DESCRIPTION
In the previous [MR]( https://github.com/webzard-io/k8s-api-provider/pull/25), we added the forceapply parameter to applyYaml, but if we can distinguish between edit and create, we should call the corresponding method, so we should implement createyaml