### PR TITLE
fix: data api's get one throw error when get empty data and transform http error

### DIFF
--- a/__tests__/utils/transform-http-error.spec.ts
+++ b/__tests__/utils/transform-http-error.spec.ts
@@ -1,0 +1,56 @@
+import { transformHttpError } from '../../src/utils/transform-http-error';
+
+describe('transformHttpError', () => {
+  it('should return an HttpError object with statusText and status code if error has response', () => {
+    const error = {
+      response: {
+        statusText: 'Not Found',
+        status: 404,
+      },
+    };
+
+    const expected = {
+      ...error,
+      message: 'Not Found',
+      statusCode: 404,
+    };
+
+    expect(transformHttpError(error)).toEqual(expected);
+  });
+
+  it('should return an HttpError object with error message, undefined statusCode if error does not have response', () => {
+    const error = new Error('Internal Server Error');
+
+    const expected = {
+      error: error,
+      message: 'Internal Server Error',
+      statusCode: undefined,
+    };
+
+    expect(transformHttpError(error)).toEqual(expected);
+  });
+
+  it('should return an HttpError object with error message as JSON string if error is an object', () => {
+    const error = { message: 'Bad Request' };
+
+    const expected = {
+      error: error,
+      message: '{"message":"Bad Request"}',
+      statusCode: undefined,
+    };
+
+    expect(transformHttpError(error)).toEqual(expected);
+  });
+
+  it('should return an HttpError object with error message as string if error is not an object', () => {
+    const error = 'Unauthorized';
+
+    const expected = {
+      error: error,
+      message: 'Unauthorized',
+      statusCode: undefined,
+    };
+
+    expect(transformHttpError(error)).toEqual(expected);
+  });
+});

--- a/src/utils/transform-http-error.ts
+++ b/src/utils/transform-http-error.ts
@@ -1,0 +1,21 @@
+import { HttpError } from '@refinedev/core';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const transformHttpError = (error: any): HttpError => {
+  if (error?.response) {
+    return {
+      ...error,
+      message: error.response?.statusText,
+      statusCode: error.response?.status,
+    };
+  }
+  return {
+    error: error,
+    message:
+      typeof error === 'object'
+        ? error instanceof Error
+          ? error.message
+          : JSON.stringify(error)
+        : String(error),
+    statusCode: undefined as unknown as number,
+  };
+};


### PR DESCRIPTION
- Instead of returning structured data, an error should be thrown if getOne does not find a match.
- Since refine imposes strict limits on the types of errors, we uniformly return errors of the `HttpError` structure.