### PR TITLE
feat(kube-api): implement cancel query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+/.pnpm-store
 
 # testing
 /coverage

--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -132,6 +132,7 @@ export const dataProvider = (
       const sdk = new KubeSdk({
         basePath: globalStore.apiUrl,
         fieldManager: globalStore.fieldManager,
+        kubeApiTimeout: globalStore.kubeApiTimeout,
       });
       try {
         const data = await sdk.createyYaml([
@@ -198,8 +199,8 @@ export const dataProvider = (
         const sdk = new KubeSdk({
           basePath: globalStore.apiUrl,
           fieldManager: globalStore.fieldManager,
+          kubeApiTimeout: globalStore.kubeApiTimeout,
         });
-
         const { data: current } = await getOne({ id, resource, meta, ...rest });
 
         const data = await sdk.deleteYaml([current as Unstructured]);


### PR DESCRIPTION
In the original implementation, we didn't manage the timeout for http requests, we set the timeout parameter of ky to false for get data, which means it never times out, and we didn't set the timeout parameter for put/post data, which will result in a default timeout after 1000ms. Since there are requests that don't timeout, it's very likely that we'll trigger the browser's maximum request limit, causing subsequent requests (including non-dataprovider requests) to be pedding. This will have unintended consequences, especially if there are dynamically loaded js files. Therefore, in this PR, we have made the following changes.

- A new `cancelQuery` method has been added, which allows us to cancel the query at the desired point (usually within the lifecycle hook of the corresponding component's destruction).
- Newly exposed the kubeApiTimeout parameter, which allows the user to customize the desired timeout.
- Fixed the stopWatch function, which is expected to be executed for every resource.
