### PR TITLE
call restoreItem func of plugins in reversed order

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -165,7 +165,8 @@ export class GlobalStore {
 
   restoreItem(item: Unstructured): Unstructured {
     let nextItem = item;
-    for (const plugin of this.plugins) {
+    // restore in reversed order
+    for (const plugin of [...this.plugins].reverse()) {
       nextItem = plugin.restoreItem(nextItem);
     }
     return nextItem;
@@ -173,7 +174,8 @@ export class GlobalStore {
 
   restoreData(list: UnstructuredList): UnstructuredList {
     let nextList = list;
-    for (const plugin of this.plugins) {
+    // restore in reversed order
+    for (const plugin of [...this.plugins].reverse()) {
       nextList = plugin.restoreData(nextList);
     }
     return nextList;


### PR DESCRIPTION
### Bug 描述
现在对model调用 restoreItem 时，结果仍然会有relations，没有restore干净。

### 原因
目前Plugin的proceesItem和restoreItem都是按顺序调用的。目前的顺序是 [relationPlugin, modelPlugin]。结果就是先调用了的relationPlugin的restoreItem，去掉了relation。但是modelPlugin的restoreItem直接返回了rawYaml，导致结果还是有relation。应该反过来，先拿到rawYaml，再去掉relation才正确。

因此，在restoreItem的时候按照plugins的反向顺序调用更加合理一些。