### PR TITLE
fix: chagne the type Unstructured

### DIFF
--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -28,8 +28,8 @@ export type UnstructuredList = {
 
 export type Unstructured = {
   id: string;
-  apiVersion: string;
-  kind: string;
+  apiVersion?: string;
+  kind?: string;
   metadata: ObjectMeta;
 };
 


### PR DESCRIPTION
Not all data in the resource list contains the `apiVersion` and `kind` field.

![image](https://github.com/webzard-io/k8s-api-provider/assets/25414733/8092dfe2-9010-4f89-a9a9-60841de0c35a)
