### PR TITLE
chore: remove the minify option

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,6 @@ export default defineConfig(options => ({
   sourcemap: true,
   clean: !options.watch,
   metafile: !options.watch,
-  minify: !options.watch,
   platform: 'browser',
   outDir: 'lib',
 }));


### PR DESCRIPTION
Don't need to minify the file when building which would lead to can't set the break point in the web dev tool. It should be minified in the other project which uses this lib.