### PR TITLE
fix cache quest lock condition

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -1,5 +1,4 @@
 import { MetaQuery } from '@refinedev/core';
-import { isEqual } from 'lodash';
 import {
   KubeApi,
   UnstructuredList,
@@ -74,7 +73,11 @@ export class GlobalStore {
     }
 
     const cacheRequest = this.requestsCache.find(f => {
-      return f.resource === resource && isEqual(f.meta, meta);
+      // TODO: Its supposed to be strictly comparison of query path
+      return (
+        f.resource === resource &&
+        f.meta?.resourceBasePath === meta?.resourceBasePath
+      );
     });
 
     // return cached fetching request


### PR DESCRIPTION
In the previous PR https://github.com/webzard-io/k8s-api-provider/pull/34, we added a synchronization lock to `globalStore.get()` to ensure that only one valid http(s) and wbsocket(s) request is sent for the same resource concurrently, but the lock is not sufficiently restrictive: the lock is only added if the request parameters are identical, for the following reason:
- The parameters passed to the dataprovider by the caller will only be used inside the dataprovider and not sent to the k8s api server, the actual request parameters sent to the api server should be determined by the dataprovider.
- In one globalstore instance, we should strictly ensure that only one list watch exists for a resource at a time, otherwise there will be unintended consequences.

This PR also adds the cancelquery logic that was missing: when the websocket readyState is CONNECTING, the connection should also be closed.

