### PR TITLE
fix(globalstore): fix resource namespace filter

### DIFF
--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -59,6 +59,11 @@ export const dataProvider = (
       try {
         const { resource, pagination, filters, sorters, meta } = params;
         let { items } = await globalStore.get<TData>(resource, meta);
+
+        if (meta?.namespace) {
+          items = items.filter((item: Unstructured) => item.metadata.namespace === meta.namespace);
+        }
+
         if (filters) {
           items = filterData(filters, items);
         }
@@ -66,6 +71,7 @@ export const dataProvider = (
         if (sorters) {
           items = sortData(sorters, items);
         }
+
         const _total = items.length;
         if (pagination) {
           items = paginateData(pagination, items);

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -15,7 +15,6 @@ export function getObjectConstructor(resource: string, meta?: MetaQuery) {
     ? {
         resourceBasePath: meta?.resourceBasePath,
         resource: meta?.k8sResource || resource,
-        namespace: meta.namespace,
       }
     : {
         resourceBasePath: '/api/v1',


### PR DESCRIPTION
In the original implementation, we added namespace to the meta attribute of the data-provider in order to implement the k8s api server's filter by namespace feature. However, we ignored the fact that the cache key in the globalstore is the resource name. This will result in an incorrect cache being returned when switching namespaces for the same resource (including switching to all namespaces).The following fixes have been made in this PR：
- Removed the specific namespace parameter for requesting api-server, meaning that  the current resource will be returned fully anyway.
- Filtering the namespace needed within the dataprovider.
