### PR TITLE
enable cascading deletion

### DIFF
--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -833,6 +833,14 @@ export class KubeSdk {
       .delete(url, {
         timeout: this.kubeApiTimeout,
         retry: 0,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          kind: 'DeleteOptions',
+          apiVersion: 'batch/v1',
+          propagationPolicy: 'Background',
+        }),
       })
       .json();
 


### PR DESCRIPTION
显式开启k8s的级联删除功能。
k8s文档中说这是默认开启的，但实际上没开启，所以显式配置这个参数，开启级联删除。

https://kubernetes.io/zh-cn/docs/tasks/administer-cluster/use-cascading-deletion/