### PR TITLE
fix: 🐛 kube api reset retry state after reconnect

### DIFF
--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -478,6 +478,7 @@ export class KubeApi<T extends UnstructuredList> {
         socket.close(3001, 'KUBEAPI_MANUAL_CLOSE');
         return;
       }
+      this.resetRetryState();
       heartbeat(socket);
       removeAbortListener();
     });

--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -68,6 +68,7 @@ type KubeApiListWatchOptions<T> = KubeApiListOptions & {
   onResponse?: (response: T) => void;
   onEvent?: (event: WatchEvent) => void;
   signal?: AbortSignal;
+  retryFlag?: boolean;
 };
 
 type KubeApiLinkRef = {
@@ -284,17 +285,39 @@ export class KubeApi<T extends UnstructuredList> {
     onResponse,
     onEvent,
     signal,
+    retryFlag = false,
   }: KubeApiListWatchOptions<T> = {}): Promise<StopWatchHandler> {
     const url = this.getUrl({ namespace });
     const watchUrl = this.watchWsBasePath
       ? this.getUrl({ namespace }, undefined, true)
       : url;
-
+    let stop = () => {};
     const response = await this.list({
       namespace,
       query,
       fetchOptions: { timeout: this.kubeApiTimeout, signal },
+    }).catch(error => {
+      if (retryFlag) {
+        this.retryFunc(async () => {
+          stop = await this.listWatch({
+            namespace,
+            query,
+            onResponse,
+            onEvent,
+            retryFlag: true,
+          });
+        });
+
+        stop = () => {
+          this.resetRetryState();
+        };
+      } else {
+        throw error;
+      }
     });
+    if (!response) {
+      return stop;
+    }
     const stopWatch = await this.watch(
       watchUrl,
       response,
@@ -305,10 +328,11 @@ export class KubeApi<T extends UnstructuredList> {
         query,
         onResponse,
         onEvent,
+        retryFlag: true,
       }),
       signal
     );
-    const stop = () => {
+    stop = () => {
       stopWatch?.();
     };
     onResponse?.(response);
@@ -499,7 +523,7 @@ export class KubeApi<T extends UnstructuredList> {
       });
 
       stopWatch = () => {
-        clearTimeout(this.retryTimer);
+        this.resetRetryState();
       };
     });
 


### PR DESCRIPTION
在原先 ListWatch 的重连逻辑中，存在以下问题：
- 在 websocket 被异常断开后，会触发指数退避重连，在 websocket 重连成功后，需要清理重连状态
- 只处理了 ListWatch 的 wtach 异常重连，未对 list 操作的异常进行重连

当前 PR 包含以下修改：
- 在重连后清理对应的状态字端
- 对重连过程中的 list 操作增加异常重连；对于首次由外部触发（UI）的 ListWatch ，抛出异常，由 UI 手动点击重试进行重连

自测：
![image](https://github.com/webzard-io/k8s-api-provider/assets/18740395/336f2f22-0fc1-46a9-bfa0-5ca2cc476448)

![iShot_2024-04-18_13 41 55](https://github.com/webzard-io/k8s-api-provider/assets/18740395/f955f84d-e769-4ec0-bbe7-056a07a7a8c5)


![iShot_2024-04-18_14 39 23](https://github.com/webzard-io/k8s-api-provider/assets/18740395/41f7c10f-a4ee-47bf-855e-3e641a8ab418)
