### PR TITLE
fix: 🐛 fix missed fieldManager field

### DIFF
--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -804,6 +804,9 @@ export class KubeSdk {
         retry: 0,
         timeout: this.kubeApiTimeout,
         json: spec,
+        searchParams: {
+          fieldManager: this.fieldManager || 'refine',
+        },
       })
       .json();
 
@@ -832,13 +835,10 @@ export class KubeSdk {
         timeout: this.kubeApiTimeout,
         retry: 0,
         json,
-        searchParams:
-          strategy === 'application/apply-patch+yaml'
-            ? {
-                fieldManager: this.fieldManager || 'refine',
-                force: true,
-              }
-            : undefined,
+        searchParams: {
+          fieldManager: this.fieldManager || 'refine',
+          ...(strategy === 'application/apply-patch+yaml' && { force: true }),
+        },
       })
       .json();
 
@@ -852,6 +852,9 @@ export class KubeSdk {
         retry: 0,
         timeout: this.kubeApiTimeout,
         json: spec,
+        searchParams: {
+          fieldManager: this.fieldManager || 'refine',
+        },
       })
       .json();
 


### PR DESCRIPTION
In the past kube api implementations, the fieldManager field was only added when applying yaml. The fieldManager field was omitted when patching and putting json.

If there is no fieldManager, the API server infers a field manager identity from the "User-Agent:" HTTP header (if present).

This will result in the same field being managed by multiple UI client managers, which will result in a failure to remove the field via the client side patch

https://kubernetes.io/docs/reference/using-api/server-side-apply/#managers