### PR TITLE
fix: 🐛 fix destroy lock

### DIFF
--- a/__tests__/k8sClient.ts
+++ b/__tests__/k8sClient.ts
@@ -1,1 +1,84 @@
 // TODO(xingyu) mock k8s client
+import { KubeApi, UnstructuredList, WatchEvent, StopWatchHandler } from '../src/kube-api';
+
+export class MockKubeApi<T extends UnstructuredList = UnstructuredList> extends KubeApi<T> {
+  private mockData: T;
+  private mockEvents: WatchEvent[] = [];
+  private mockError: Error | null = null;
+  private mockStopHandler: StopWatchHandler = () => {};
+
+  constructor(options: any) {
+    super(options);
+  }
+
+  setMockData(data: T): void {
+    this.mockData = data;
+  }
+
+  setMockEvents(events: WatchEvent[]): void {
+    this.mockEvents = events;
+  }
+
+  setMockError(error: Error): void {
+    this.mockError = error;
+  }
+
+  setMockStopHandler(handler: StopWatchHandler): void {
+    this.mockStopHandler = handler;
+  }
+
+  async list(): Promise<T> {
+    if (this.mockError) {
+      return Promise.reject(this.mockError);
+    }
+    return Promise.resolve(this.mockData);
+  }
+
+  async listWatch({
+    onResponse,
+    onEvent,
+    signal,
+  }: {
+    onResponse?: (response: T, event?: WatchEvent) => void;
+    onEvent?: (event: WatchEvent) => void;
+    signal?: AbortSignal;
+  } = {}): Promise<StopWatchHandler> {
+    if (this.mockError) {
+      return Promise.reject(this.mockError);
+    }
+
+    // Simulate initial response
+    if (onResponse) {
+      onResponse(this.mockData);
+    }
+
+    // Simulate events
+    if (this.mockEvents.length > 0) {
+      setTimeout(() => {
+        this.mockEvents.forEach(event => {
+          if (signal?.aborted) return;
+          
+          if (onEvent) {
+            onEvent(event);
+          }
+          
+          if (onResponse) {
+            onResponse(this.mockData, event);
+          }
+        });
+      }, 10);
+    }
+
+    return Promise.resolve(this.mockStopHandler);
+  }
+
+  resetRetryState(): void {
+    // Mock implementation
+  }
+}
+
+export function createMockKubeApiFactory() {
+  return jest.fn().mockImplementation((options: any) => {
+    return new MockKubeApi(options);
+  });
+}

--- a/__tests__/utils/extract-path.spec.ts
+++ b/__tests__/utils/extract-path.spec.ts
@@ -3,13 +3,16 @@ import { extractPath } from '../../src/utils/extract-path';
 import { Unstructured } from '../../src/kube-api';
 
 describe('extractPath', () => {
-  const mockItems: Unstructured[] = [
+  const mockItems = [
     {
+      id: '1',
       metadata: {
         name: 'parent',
         namespace: 'default'
       },
       spec: {
+        name: 'test',
+        namespace: 'default',
         containers: [
           {
             name: 'container1',
@@ -23,6 +26,7 @@ describe('extractPath', () => {
       }
     },
     {
+      id: '2',
       metadata: {
         name: 'parent2',
         namespace: 'test'
@@ -96,7 +100,7 @@ describe('extractPath', () => {
   });
 
   test('should handle items without metadata', () => {
-    const itemsWithoutMetadata: Unstructured[] = [
+    const itemsWithoutMetadata = [
       {
         spec: {
           containers: [
@@ -109,7 +113,7 @@ describe('extractPath', () => {
       }
     ];
 
-    const result = extractPath('[0].spec.containers', itemsWithoutMetadata);
+    const result = extractPath('[0].spec.containers', itemsWithoutMetadata as unknown as Unstructured[]);
     
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({

--- a/__tests__/utils/filter-data.spec.ts
+++ b/__tests__/utils/filter-data.spec.ts
@@ -5,16 +5,19 @@ import { Unstructured } from '../../lib';
 describe('filterData function', () => {
   const unstructuredData = [
     {
+      id: '1',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod A', namespace: 'Namespace A' },
     },
     {
+      id: '2',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod B', namespace: 'Namespace B' },
     },
     {
+      id: '3',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod C', namespace: 'Namespace A' },
@@ -28,11 +31,13 @@ describe('filterData function', () => {
     const filteredData = filterData(filters as CrudFilters, unstructuredData);
     const expectedFilteredData = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A', namespace: 'Namespace A' },
       },
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C', namespace: 'Namespace A' },
@@ -54,11 +59,13 @@ describe('filterData function', () => {
     const filteredData = filterData(filters as CrudFilters, unstructuredData);
     const expectedFilteredData = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A', namespace: 'Namespace A' },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B', namespace: 'Namespace B' },
@@ -80,6 +87,7 @@ describe('filterData function', () => {
     const filteredData = filterData(filters as CrudFilters, unstructuredData);
     const expectedFilteredData = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A', namespace: 'Namespace A' },
@@ -118,6 +126,7 @@ describe('filterData function', () => {
     ];
     const data: (Unstructured & { status: { state: string; } })[] = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A', namespace: 'Namespace A' },
@@ -126,6 +135,7 @@ describe('filterData function', () => {
         },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B', namespace: 'Namespace B' },
@@ -134,6 +144,7 @@ describe('filterData function', () => {
         },
       },
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C', namespace: 'Namespace A', deletionTimestamp: 'mock time' },
@@ -151,6 +162,7 @@ describe('filterData function', () => {
         ],
       },
     ], data)).toEqual([{
+      id: '1',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod A', namespace: 'Namespace A' },
@@ -167,6 +179,7 @@ describe('filterData function', () => {
         ],
       },
     ], data)).toEqual([{
+      id: '2',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod B', namespace: 'Namespace B' },
@@ -183,6 +196,7 @@ describe('filterData function', () => {
         ],
       },
     ], data)).toEqual([{
+      id: '3',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod C', namespace: 'Namespace A', deletionTimestamp: 'mock time' },
@@ -209,6 +223,7 @@ describe('filterData function', () => {
 
 describe('evaluateFilter function', () => {
   const mockItem = {
+    id: '1',
     apiVersion: 'v1',
     kind: 'Pod',
     metadata: {

--- a/__tests__/utils/paginate-data.spec.ts
+++ b/__tests__/utils/paginate-data.spec.ts
@@ -4,39 +4,46 @@ import { Pagination } from '@refinedev/core';
 describe('paginateData function', () => {
   const unstructuredData = [
     {
+      id: '1',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod A' },
     },
     {
+      id: '2',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod B' },
     },
     {
+      id: '3',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod C' },
     },
     {
+      id: '4',
       apiVersion: 'v1',
       kind: 'Pod',
-      metadata: { name: 'Pod C' },
+      metadata: { name: 'Pod D' },
     },
     {
+      id: '5',
       apiVersion: 'v1',
       kind: 'Pod',
-      metadata: { name: 'Pod C' },
+      metadata: { name: 'Pod E' },
     },
     {
+      id: '6',
       apiVersion: 'v1',
       kind: 'Pod',
-      metadata: { name: 'Pod C' },
+      metadata: { name: 'Pod F' },
     },
     {
+      id: '7',
       apiVersion: 'v1',
       kind: 'Pod',
-      metadata: { name: 'Pod C' },
+      metadata: { name: 'Pod G' },
     },
   ];
 
@@ -54,7 +61,7 @@ describe('paginateData function', () => {
   it('should no paginate data with custom settings', () => {
     const pagination = { current: 2, pageSize: 2, mode: 'off' };
     console.warn = jest.fn(); // mock error
-    const paginatedData = paginateData(pagination, unstructuredData);
+    const paginatedData = paginateData(pagination as Pagination, unstructuredData);
     const expectedPaginatedData = unstructuredData
     expect(paginatedData).toEqual(expectedPaginatedData);
     expect(console.warn).toHaveBeenCalledWith(

--- a/__tests__/utils/sort-data.spec.ts
+++ b/__tests__/utils/sort-data.spec.ts
@@ -4,16 +4,19 @@ import { CrudSorting } from '@refinedev/core';
 describe('sortData function', () => {
   const unstructuredData = [
     {
+      id: '1',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod A' },
     },
     {
+      id: '2',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod B' },
     },
     {
+      id: '3',
       apiVersion: 'v1',
       kind: 'Pod',
       metadata: { name: 'Pod C' },
@@ -46,16 +49,19 @@ describe('sortData function', () => {
     const sortedData = sortData(sorting as CrudSorting, unstructuredData);
     const expectedSortedData = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A' },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B' },
       },
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C' },
@@ -69,16 +75,19 @@ describe('sortData function', () => {
     const sortedData = sortData(sorting as CrudSorting, unstructuredData);
     const expectedSortedData = [
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C' },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B' },
       },
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A' },
@@ -95,16 +104,19 @@ describe('sortData function', () => {
     const sortedData = sortData(sorting as CrudSorting, unstructuredData);
     const expectedSortedData = [
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C' },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B' },
       },
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A' },
@@ -117,16 +129,19 @@ describe('sortData function', () => {
     const sortedData = sortData(sorting as CrudSorting, unstructuredData);
     const expectedSortedData = [
       {
+        id: '1',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod A' },
       },
       {
+        id: '2',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod B' },
       },
       {
+        id: '3',
         apiVersion: 'v1',
         kind: 'Pod',
         metadata: { name: 'Pod C' },

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,6 @@ module.exports = {
   ],
   testPathIgnorePatterns: ['/node_modules/', '/lib/', '<rootDir>/lib/'],
 
-  testEnvironment: 'node',
   maxWorkers: '50%',
   collectCoverage: Boolean(process.env.COVERAGE),
   collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
@@ -30,5 +29,9 @@ module.exports = {
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,
+  },
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^lodash-es$': 'lodash',
   },
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "kubernetes-types": "^1.26.0",
     "ky": "^0.33.3",
-    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.15",
     "mitt": "^3.0.1"
   },
   "devDependencies": {
@@ -56,7 +56,7 @@
     "@kubernetes/client-node": "^0.18.1",
     "@refinedev/core": "^4.44.4",
     "@types/jest": "^29",
-    "@types/lodash": "^4.14.149",
+    "@types/lodash-es": "^4.17.1",
     "@types/node": "^18.16.2",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
@@ -65,7 +65,7 @@
     "husky": "^8.0.0",
     "jest": "^29",
     "prettier": "^2.5.0",
-    "ts-jest": "^29",
+    "ts-jest": "29.2.6",
     "tsup": "^8.1.2",
     "typescript": "^4.7.4"
   },

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -26,6 +26,7 @@ export type KubeApiFactory = (params: {
   watchWsBasePath?: string;
   objectConstructor: ReturnType<typeof getObjectConstructor>;
   kubeApiTimeout?: false | number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }) => KubeApi<any>;
 
 export interface GlobalStoreInitParams {

--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -1,6 +1,6 @@
 // highly inspired by https://github.com/lensapp/lens/blob/1a29759bff/src/common/k8s-api/kube-api.ts
 import ky, { SearchParamsOption, Options } from 'ky';
-import { get, cloneDeep } from 'lodash';
+import { get, cloneDeep } from 'lodash-es';
 import type {
   APIResource,
   APIResourceList,

--- a/src/utils/extract-path.ts
+++ b/src/utils/extract-path.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { get } from 'lodash-es';
 import { Unstructured } from '../kube-api';
 
 interface ExtractedMetadata {
@@ -28,7 +28,7 @@ export const extractPath = (extractPathName: string, items: Unstructured[]): Uns
   // Parse the parent index from extractPathName
   const parentIndex = extractPathName.match(/^\[(\d+)\]/)?.[1];
   const parentItem = parentIndex !== undefined ? items[parseInt(parentIndex, 10)] : items[0];
-  const extractedData = _.get(items, extractPathName);
+  const extractedData = get(items, extractPathName);
   
   if (!extractedData) {
     return [];

--- a/src/utils/filter-data.ts
+++ b/src/utils/filter-data.ts
@@ -1,5 +1,5 @@
 import { CrudFilter, CrudFilters, CrudOperators } from '@refinedev/core';
-import _ from 'lodash';
+import { get, has, isNil, includes } from 'lodash-es';
 import { Unstructured } from '../kube-api';
 
 type Filter = CrudFilter & {
@@ -43,11 +43,11 @@ export function evaluateFilter(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any
 ): boolean {
-  if (!_.has(item, field)) {
+  if (!has(item, field)) {
     return false;
   }
-
-  const fieldValue = _.get(item, field);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fieldValue:any = get(item, field);
 
   switch (operator) {
     case 'eq':
@@ -68,7 +68,7 @@ export function evaluateFilter(
       }
       return value.some(item => {
         if (Array.isArray(fieldValue)) {
-          return _.includes(fieldValue, item);
+          return includes(fieldValue, item);
         }
         return item === fieldValue;
       });
@@ -79,28 +79,28 @@ export function evaluateFilter(
       }
       return value.every(item => {
         if (Array.isArray(fieldValue)) {
-          return !_.includes(fieldValue, item);
+          return !includes(fieldValue, item);
         }
         return item !== fieldValue;
       });
     }
     case 'contains':
-      return _.includes(fieldValue, value);
+      return includes(fieldValue, value);
     case 'ncontains':
-      return !_.includes(fieldValue, value);
+      return !includes(fieldValue, value);
     case 'containss':
-      return _.includes(fieldValue.toLowerCase(), value.toLowerCase());
+      return includes(fieldValue.toLowerCase(), value.toLowerCase());
     case 'ncontainss':
-      return !_.includes(fieldValue.toLowerCase(), value.toLowerCase());
+      return !includes(fieldValue.toLowerCase(), value.toLowerCase());
     case 'between':
       return value[0] <= fieldValue && fieldValue <= value[1];
     case 'nbetween':
       return value[0] > fieldValue || fieldValue > value[1];
     case 'null': {
-      return _.isNil(fieldValue);
+      return isNil(fieldValue);
     }
     case 'nnull': {
-      return !_.isNil(fieldValue);
+      return !isNil(fieldValue);
     }
     case 'startswith':
       return fieldValue.startsWith(value);
@@ -117,6 +117,6 @@ export function evaluateFilter(
     case 'endswiths':
       return fieldValue.toLowerCase().endsWith(value.toLowerCase());
     case 'nendswiths':
-      return !fieldValue.toLowerCase().endsWith(value.toLowerCase());
+      return !(fieldValue).toLowerCase().endsWith((value).toLowerCase());
   }
 }

--- a/src/utils/sort-data.ts
+++ b/src/utils/sort-data.ts
@@ -1,5 +1,5 @@
 import { CrudSorting } from '@refinedev/core';
-import _ from 'lodash';
+import { get, isNil } from 'lodash-es';
 import { Unstructured } from '../kube-api';
 
 export function sortData(
@@ -11,15 +11,15 @@ export function sortData(
   return [...data].sort((a, b) => {
     for (const sort of sorting) {
       const { field, order } = sort;
-      const aValue = _.get(a, field);
-      const bValue = _.get(b, field);
-      if (_.isNil(aValue) && _.isNil(bValue)) {
+      const aValue = get(a, field);
+      const bValue = get(b, field);
+      if (isNil(aValue) && isNil(bValue)) {
         continue;
       }
-      if (_.isNil(aValue)) {
+      if (isNil(aValue)) {
         return order === 'asc' ? 1 : -1;
       }
-      if (_.isNil(bValue)) {
+      if (isNil(bValue)) {
         return order === 'asc' ? -1 : 1;
       }
       if (aValue < bValue) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "module": "ESNext",
     "outDir": "lib/typings",
     "lib": ["dom", "esnext", "dom.iterable"],
     "rootDir": "src",
@@ -11,7 +12,8 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution":"node"
+    "moduleResolution": "node",
+    "allowJs": true
   },
   "include": ["src"],
   "exclude": ["__tests__", "lib"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1223,10 +1223,17 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz#02c24f4363176d2d18fc8b70b9f3c54aba178a85"
   integrity sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==
 
-"@types/lodash@^4.14.149":
-  version "4.14.199"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz#c3edb5650149d847a277a8961a7ad360c474e9bf"
-  integrity sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==
+"@types/lodash-es@^4.17.1":
+  version "4.17.12"
+  resolved "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.16"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
+  integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
 
 "@types/minimist@^1.2.0":
   version "1.2.3"
@@ -1523,6 +1530,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
+async@^3.2.3:
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1661,7 +1673,7 @@ browserslist@^4.21.9:
     node-releases "^2.0.13"
     update-browserslist-db "^1.0.13"
 
-bs-logger@0.x:
+bs-logger@^0.2.6:
   version "0.2.6"
   resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
@@ -1761,7 +1773,7 @@ chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2150,6 +2162,13 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ejs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.4.535:
   version "1.4.544"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.544.tgz#fcb156d83f0ee6e4c9d030c6fedb2a37594f3abf"
@@ -2454,6 +2473,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+filelist@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
+  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  dependencies:
+    minimatch "^5.0.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -3070,6 +3096,16 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jake@^10.8.5:
+  version "10.9.2"
+  resolved "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz#6ae487e6a69afec3a5e167628996b59f35ae2b7f"
+  integrity sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.4"
+    minimatch "^3.1.2"
+
 jest-changed-files@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
@@ -3606,7 +3642,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
+lodash-es@^4.17.15, lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -3636,7 +3672,7 @@ lodash.map@^4.5.1:
   resolved "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==
 
-lodash.memoize@4.x:
+lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
@@ -3720,7 +3756,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@^1.1.1, make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -3810,6 +3846,13 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimatch@^9.0.4:
   version "9.0.5"
@@ -4462,6 +4505,11 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
+semver@^7.7.1:
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -4860,19 +4908,20 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-ts-jest@^29:
-  version "29.1.1"
-  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz#f58fe62c63caf7bfcc5cc6472082f79180f0815b"
-  integrity sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==
+ts-jest@29.2.6:
+  version "29.2.6"
+  resolved "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz#df53edf8b72fb89de032cfa310abf37582851d9a"
+  integrity sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==
   dependencies:
-    bs-logger "0.x"
-    fast-json-stable-stringify "2.x"
+    bs-logger "^0.2.6"
+    ejs "^3.1.10"
+    fast-json-stable-stringify "^2.1.0"
     jest-util "^29.0.0"
     json5 "^2.2.3"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    semver "^7.5.3"
-    yargs-parser "^21.0.1"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.7.1"
+    yargs-parser "^21.1.1"
 
 ts-node@^10.8.1:
   version "10.9.1"
@@ -5167,7 +5216,7 @@ yargs-parser@^20.2.3:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.0.1, yargs-parser@^21.1.1:
+yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==


### PR DESCRIPTION
add destroy lock

Vulnerability in destroy: After calling destroy, registration of subsequent callbacks should be disabled.


BTW: cause of `ky` package only builds ESM bundle, jest didn't work with it.