### PR TITLE
fix: fix globalStore modify event race condition

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -137,11 +137,25 @@ export class GlobalStore {
               resolve(processedRes as unknown as T);
               resolved = true;
             }
-            this.store.set(resource, processedRes);
 
-            if (event) {
-              await this.processItem(event.object);
-              this.notify(resource, event);
+            let shouldUpdateStore = true;
+            if (event?.type === 'MODIFIED') {
+              // 防止因为竞态问题，导致数据已经被删除了，但是又一次被添加回去
+              const existingResource = this.store.get(resource);
+              const isObjectExist = existingResource?.items.some(
+                (item: Unstructured) =>
+                  item.metadata?.name === event.object.metadata?.name &&
+                  item.metadata?.namespace === event.object.metadata?.namespace
+              );
+              shouldUpdateStore = !!isObjectExist;
+            }
+
+            if (shouldUpdateStore) {
+              this.store.set(resource, processedRes);
+              if (event) {
+                await this.processItem(event.object);
+                this.notify(resource, event);
+              }
             }
             // TODO: if the request onResponse is timeout, the cache request will not be removed
             this.removeCacheRequest(promise);


### PR DESCRIPTION
修改和删除有可能有竞态关系。当短时间内收到修改和删除事件时，若修改的异步处理`processData`较慢，可能导致UI状态不一致。结果导致先发生的修改事件，在删除事件之后执行，导致已删除的资源仍然存在。

修复方法是，收到修改事件后，在异步操作完成后，更新store之前，检查资源是否存在，如果已经不存在，就不再添加。