### PR TITLE
feat: add network-only mode for the global store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k8s-api-provider",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "K8s ui data provider",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -9,6 +9,10 @@ import {
 import { IProviderPlugin } from './plugin';
 import { genResourceId } from './utils/gen-resource-id';
 
+export enum RequestMode {
+  NetworkOnly = 'network-only',
+}
+
 export function getObjectConstructor(resource: string, meta?: MetaQuery) {
   return meta?.resourceBasePath
     ? {
@@ -88,12 +92,13 @@ export class GlobalStore {
       this.requestsCache.splice(cacheRequestIndex, 1);
     }
   }
+
   get<T = UnstructuredList>(resource: string, meta?: MetaQuery): Promise<T> {
     if (this._isDestroyed) {
       return Promise.reject('GlobalStore has been destroyed');
     }
 
-    if (this.store.has(resource)) {
+    if (this.store.has(resource) && meta?.mode !== RequestMode.NetworkOnly) {
       // return cached data
       return new Promise(resolve => {
         resolve(this.store.get(resource)! as unknown as T);


### PR DESCRIPTION
现在的 store 是以 resourceName 为 key 进行缓存的，但同一个资源可能会存在不同的 API 版本，没法满足同时获取一个资源不同版本的需求。

如果要完全支持的话，store key 还需要加上 `resourceBasePath` 进行缓存，但现在外部调用很多地方都只传 resourceName 且不带 meta，修改后对外部影响较大，先不进行这么修改。

先增加 `network-only` 模式跳过缓存进行临时解决。