### PR TITLE
ci: upgrade GitHub Actions to v4 and enable npm provenance

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -12,10 +12,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
       - run: yarn
       - run: yarn test
       - run: yarn build
@@ -23,14 +23,16 @@ jobs:
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # OIDC token 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
+          node-version: 24
       - run: yarn
       - run: yarn build
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      # Ensure OIDC flow is used without stale npm auth tokens.
+      - run: npm config delete //registry.npmjs.org/:_authToken
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
- Upgrade actions/checkout and actions/setup-node from v3 to v4
- Add OIDC permissions for npm provenance support
- Enable --provenance flag for supply chain security

https://github.com/webzard-io/k8s-api-provider/actions/runs/20688606595/job/59393382830