### PR TITLE
fix: clean up stale watchBySdk listener on watch retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k8s-api-provider",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "K8s ui data provider",
   "main": "lib/index.js",
   "module": "lib/index.js",

--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -418,7 +418,13 @@ export class KubeApi<T extends UnstructuredList> {
     };
 
     // client-side watch simulated by applyYaml
-    stops.push(this.watchBySdk(response, handleEvent));
+    const stopSdkWatch = this.watchBySdk(response, handleEvent);
+    stops.push(stopSdkWatch);
+
+    const retryWithCleanup = async () => {
+      stopSdkWatch();
+      return retry();
+    };
 
     // server-side watch
     const resource = await this.apiVersionResourceCache.resourceByName(
@@ -432,10 +438,18 @@ export class KubeApi<T extends UnstructuredList> {
     if (supportServerWatch) {
       if (this.watchWsBasePath) {
         stops.push(
-          this.watchByWebsocket(url, response, handleEvent, retry, signal)
+          this.watchByWebsocket(
+            url,
+            response,
+            handleEvent,
+            retryWithCleanup,
+            signal
+          )
         );
       } else {
-        stops.push(this.watchByHttp(url, response, handleEvent, retry));
+        stops.push(
+          this.watchByHttp(url, response, handleEvent, retryWithCleanup)
+        );
       }
     }
     return () => {


### PR DESCRIPTION
## 问题描述

资源创建成功后放置较长时间，再对该资源进行编辑，编辑完成后资源从列表中消失，刷新页面后才能正确展示。

### 复现步骤

1. 打开资源列表页面，等待 WebSocket watch 连接建立
2. **等待足够长的时间**，使 WebSocket 连接断开并自动重连（retry）完成
3. 重连完成后，通过**非 KubeSdk 路径**创建资源 X（例如通过 controller 或其他 API 创建）
4. 资源 X 正常出现在列表中
5. 对资源 X 进行编辑（通过 applyYaml 路径）
6. 编辑成功后，资源 X 从列表中消失
7. 刷新页面后，资源 X 又正确显示

### 根因分析

当 WebSocket 断开触发 retry 时，watch() 方法内部的 watchBySdk（通过 event.on('change', onChange) 注册的 SDK 事件监听器）**没有被清理**。retry 会创建新的 listWatch，注册新的 watchBySdk，但旧的监听器仍然存活。

这导致以下问题链：

1. **旧监听器的 items 缺少资源 X**：资源 X 是在 WS 重连后通过非 KubeSdk 路径创建的，只通过新 WS 的 ADDED 事件进入新 handler 的 items。旧 handler 的 WS 已断开且无 SDK ADDED 事件，旧 items 中没有 X
2. **编辑触发两次 onResponse**：编辑通过 applyYaml 发出 SDK MODIFIED 事件，旧和新两个 watchBySdk 监听器都收到事件，各自调用 onResponse
3. **旧 handler 先执行**：旧 handler 的 items.map() 找不到 X，返回不含 X 的列表，store.set() 将 X 从 store 中移除
4. **新 handler 被 MODIFIED 守卫拦截**：新 handler 后执行，onResponse 中的 MODIFIED 守卫检查 store 发现 X 已不存在（被第 3 步删除），判定为"已删除的资源不应被加回"，跳过 store.set()
5. **X 永久消失**：正确的数据被丢弃，直到页面刷新重新 list() 才恢复

### 修复方案

在 watch() 方法中，将传递给 watchByWebsocket 和 watchByHttp 的 retry 回调包装为 retryWithCleanup。在 retry 执行前先调用 stopSdkWatch() 清理旧的 SDK 事件监听器（event.off('change', onChange)），确保重连后只有新的监听器存活。

### 影响范围

- 仅修改 KubeApi 类的 private watch() 方法，不影响任何公共 API
- event.off() 是幂等操作，多次调用安全
- watchByWebsocket 和 watchByHttp 两条 retry 路径均已覆盖

## Test plan

- [x] WS 重连后创建资源（非 SDK 路径）再编辑：资源不消失
- [x] WS 重连后编辑已有资源：资源不消失，正常更新
- [x] 正常编辑（无 WS 重连）：资源正常更新，无回归
- [ ] 多次 WS 重连后编辑：不累积泄漏的监听器
- [x] 通过 KubeSdk 创建资源：ADDED 事件正常处理
- [x] 删除资源：资源正常从列表移除