### PR TITLE
fix: retry safe resourceVersion conflicts

### DIFF
--- a/__tests__/data-provider/resource-version-conflict-retry.spec.ts
+++ b/__tests__/data-provider/resource-version-conflict-retry.spec.ts
@@ -1,0 +1,286 @@
+jest.mock('ky', () => ({
+  __esModule: true,
+  default: {
+    delete: jest.fn(),
+    get: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+import { dataProvider } from '../../src/data-provider';
+import { GlobalStore } from '../../src/global-store';
+import { KubeSdk, Unstructured, UnstructuredList } from '../../src/kube-api';
+
+const conflictMessage =
+  '当前数据已经不是最新，请关闭表单，重新打开编辑和提交。';
+
+function makeResource(
+  resourceVersion: string,
+  overrides: Partial<Unstructured> = {}
+): Unstructured {
+  return {
+    id: 'default/test',
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'test',
+      namespace: 'default',
+      resourceVersion,
+    },
+    data: {
+      key: 'value',
+    },
+    ...overrides,
+  } as Unstructured;
+}
+
+function makeList(item: Unstructured): UnstructuredList {
+  return {
+    apiVersion: 'v1',
+    kind: 'ConfigMapList',
+    metadata: {},
+    items: [item],
+  };
+}
+
+function makeHttpError(status: number, statusText = 'Conflict') {
+  return {
+    response: {
+      status,
+      statusText,
+    },
+  };
+}
+
+function makeProvider(latestResource: Unstructured) {
+  const get = jest.fn(async (_resource: string, _meta?: unknown) =>
+    makeList(latestResource)
+  );
+  const restoreItem = jest.fn((item: Unstructured) => item);
+  const provider = dataProvider({
+    apiUrl: '/api',
+    fieldManager: 'refine',
+    kubeApiTimeout: false,
+    plugins: [],
+    get,
+    restoreItem,
+  } as unknown as GlobalStore);
+
+  return {
+    get,
+    provider,
+    restoreItem,
+  };
+}
+
+function makeUpdateParams(
+  resource: Unstructured,
+  initialResource?: Unstructured,
+  updateType: 'put' | 'patch' = 'put',
+  metaOverrides: Record<string, unknown> = {}
+) {
+  return {
+    resource: 'configmaps',
+    id: 'default/test',
+    variables: resource,
+    meta: {
+      resourceBasePath: '/api/v1',
+      kind: 'ConfigMap',
+      updateType,
+      ...metaOverrides,
+      resourceVersionConflictRetry: initialResource
+        ? {
+            initialResource,
+            conflictMessage,
+          }
+        : undefined,
+    },
+  };
+}
+
+describe('dataProvider resourceVersion conflict retry', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('retries a 409 PUT when only runtime fields changed', async () => {
+    const initialResource = makeResource('1', {
+      status: { phase: 'Pending' },
+      metadata: {
+        name: 'test',
+        namespace: 'default',
+        resourceVersion: '1',
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': 'old',
+        },
+        finalizers: ['old-finalizer'],
+        managedFields: [{ manager: 'old' }],
+      },
+    } as Partial<Unstructured>);
+    const latestResource = makeResource('2', {
+      status: { phase: 'Running' },
+      metadata: {
+        name: 'test',
+        namespace: 'default',
+        resourceVersion: '2',
+        annotations: {
+          'kubectl.kubernetes.io/last-applied-configuration': 'new',
+        },
+        finalizers: ['new-finalizer'],
+        managedFields: [{ manager: 'new' }],
+      },
+    } as Partial<Unstructured>);
+    const submittedResource = makeResource('1', {
+      data: { key: 'edited' },
+    });
+    const { get, provider } = makeProvider(latestResource);
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409))
+      .mockResolvedValueOnce([makeResource('3')]);
+    const getOne = jest
+      .spyOn(KubeSdk.prototype, 'getOne')
+      .mockResolvedValueOnce(latestResource);
+
+    const result = await provider.update(
+      makeUpdateParams(submittedResource, initialResource)
+    );
+
+    expect(result.data.metadata?.resourceVersion).toBe('3');
+    expect(applyYaml).toHaveBeenCalledTimes(2);
+    expect(applyYaml.mock.calls[1][0][0].metadata?.resourceVersion).toBe('2');
+    expect(getOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: expect.objectContaining({
+          name: 'test',
+          namespace: 'default',
+        }),
+      })
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('ignores extractPathName when fetching the latest resource for retry', async () => {
+    const initialResource = makeResource('1');
+    const latestResource = makeResource('2');
+    const { get, provider } = makeProvider(latestResource);
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409))
+      .mockResolvedValueOnce([makeResource('3')]);
+    const getOne = jest
+      .spyOn(KubeSdk.prototype, 'getOne')
+      .mockResolvedValueOnce(latestResource);
+
+    await provider.update(
+      makeUpdateParams(makeResource('1'), initialResource, 'put', {
+        extractPathName: 'items',
+      })
+    );
+
+    expect(applyYaml).toHaveBeenCalledTimes(2);
+    expect(getOne).toHaveBeenCalledTimes(1);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when latest resource has real changes', async () => {
+    const initialResource = makeResource('1');
+    const latestResource = makeResource('2', {
+      data: { key: 'changed-by-server' },
+    });
+    const { provider } = makeProvider(latestResource);
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409));
+    jest.spyOn(KubeSdk.prototype, 'getOne').mockResolvedValueOnce(latestResource);
+
+    await expect(
+      provider.update(makeUpdateParams(makeResource('1'), initialResource))
+    ).rejects.toMatchObject({
+      message: conflictMessage,
+      statusCode: 409,
+    });
+
+    expect(applyYaml).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps original behavior for non-409 errors', async () => {
+    const initialResource = makeResource('1');
+    const { get, provider } = makeProvider(makeResource('2'));
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(500, 'Internal Server Error'));
+    const getOne = jest.spyOn(KubeSdk.prototype, 'getOne');
+
+    await expect(
+      provider.update(makeUpdateParams(makeResource('1'), initialResource))
+    ).rejects.toMatchObject({
+      statusCode: 500,
+    });
+
+    expect(applyYaml).toHaveBeenCalledTimes(1);
+    expect(getOne).not.toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('keeps original behavior for non-PUT updates', async () => {
+    const initialResource = makeResource('1');
+    const { get, provider } = makeProvider(makeResource('2'));
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409));
+    const getOne = jest.spyOn(KubeSdk.prototype, 'getOne');
+
+    await expect(
+      provider.update(makeUpdateParams(makeResource('1'), initialResource, 'patch'))
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    expect(applyYaml).toHaveBeenCalledTimes(1);
+    expect(getOne).not.toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('keeps original behavior when initial resource is missing', async () => {
+    const { get, provider } = makeProvider(makeResource('2'));
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409));
+    const getOne = jest.spyOn(KubeSdk.prototype, 'getOne');
+
+    await expect(
+      provider.update(makeUpdateParams(makeResource('1')))
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    expect(applyYaml).toHaveBeenCalledTimes(1);
+    expect(getOne).not.toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('does not retry more than once', async () => {
+    const initialResource = makeResource('1');
+    const { provider } = makeProvider(makeResource('2'));
+    const applyYaml = jest
+      .spyOn(KubeSdk.prototype, 'applyYaml')
+      .mockRejectedValueOnce(makeHttpError(409))
+      .mockRejectedValueOnce(makeHttpError(409));
+    jest
+      .spyOn(KubeSdk.prototype, 'getOne')
+      .mockResolvedValueOnce(makeResource('2'));
+
+    await expect(
+      provider.update(makeUpdateParams(makeResource('1'), initialResource))
+    ).rejects.toMatchObject({
+      statusCode: 409,
+    });
+
+    expect(applyYaml).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/kube-api.spec.ts
+++ b/__tests__/kube-api.spec.ts
@@ -1,0 +1,81 @@
+jest.mock('ky', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+import ky from 'ky';
+import { IProviderPlugin } from '../src/plugin';
+import { KubeSdk, Unstructured, UnstructuredList } from '../src/kube-api';
+
+function makePlugin(): IProviderPlugin {
+  return {
+    init: jest.fn(),
+    processData: jest.fn(async data => data),
+    processItem: jest.fn(async item => item),
+    restoreData: jest.fn(data => data),
+    restoreItem: jest.fn(() => undefined as unknown as Unstructured),
+  };
+}
+
+describe('KubeSdk', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('gets one resource without restoring plugin fields', async () => {
+    const plugin = makePlugin();
+    const get = ky.get as jest.Mock;
+
+    get
+      .mockReturnValueOnce({
+        json: async () => ({
+          resources: [
+            {
+              kind: 'ConfigMap',
+              name: 'configmaps',
+              namespaced: true,
+            },
+          ],
+        }),
+      })
+      .mockReturnValueOnce({
+        json: async () =>
+          ({
+            apiVersion: 'v1',
+            kind: 'ConfigMap',
+            metadata: {
+              name: 'test',
+              namespace: 'default',
+              resourceVersion: '2',
+            },
+          } as Unstructured),
+      });
+
+    const sdk = new KubeSdk(
+      {
+        basePath: '/api',
+      },
+      [plugin]
+    );
+
+    const result = await sdk.getOne({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'test',
+        namespace: 'default',
+      },
+    } as Unstructured);
+
+    expect(plugin.restoreItem).not.toHaveBeenCalled();
+    expect(result.metadata?.resourceVersion).toBe('2');
+    expect(get).toHaveBeenLastCalledWith(
+      '/api/api/v1/namespaces/default/configmaps/test',
+      expect.objectContaining({
+        retry: 0,
+      })
+    );
+  });
+});

--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -6,6 +6,7 @@ import {
   GetManyResponse,
   BaseKey,
   CreateResponse,
+  HttpError,
   MetaQuery,
   UpdateResponse,
   DeleteOneResponse,
@@ -17,9 +18,23 @@ import { paginateData } from '../utils/paginate-data';
 import {extractPath} from '../utils/extract-path';
 import { GlobalStore } from '../global-store';
 import { transformHttpError } from '../utils/transform-http-error';
+import {
+  isResourceVersionConflict,
+  ResourceVersionConflictRetryOptions,
+  retryResourceVersionConflict,
+} from './resource-version-conflict-retry';
 
 function getApiVersion(resourceBasePath: string): string {
   return resourceBasePath.replace(/^(\/api\/)|(\/apis\/)/, '');
+}
+
+function isHttpError(error: unknown): error is HttpError {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    'statusCode' in error
+  );
 }
 
 export const dataProvider = (
@@ -161,18 +176,18 @@ export const dataProvider = (
     }: Parameters<DataProvider['update']>['0']): Promise<
       UpdateResponse<TData>
     > => {
-      try {
-        const sdk = new KubeSdk(
-          {
-            basePath: globalStore.apiUrl,
-            fieldManager: globalStore.fieldManager,
-            kubeApiTimeout: globalStore.kubeApiTimeout,
-          },
-          globalStore.plugins
-        );
+      const sdk = new KubeSdk(
+        {
+          basePath: globalStore.apiUrl,
+          fieldManager: globalStore.fieldManager,
+          kubeApiTimeout: globalStore.kubeApiTimeout,
+        },
+        globalStore.plugins
+      );
+      const apply = async (targetVariables: Unstructured) => {
         const params = [
           {
-            ...(variables as unknown as Unstructured),
+            ...targetVariables,
             apiVersion: getApiVersion(meta?.resourceBasePath),
             kind: meta?.kind,
           },
@@ -184,11 +199,54 @@ export const dataProvider = (
           meta?.updateType
         );
 
+        return data[0] as unknown as TData;
+      };
+
+      try {
+        const data = await apply(variables as unknown as Unstructured);
+
         return {
-          data: data[0] as unknown as TData,
+          data,
         };
       } catch (e) {
         const httpError = transformHttpError(e);
+        const retryOptions = meta?.resourceVersionConflictRetry as
+          | ResourceVersionConflictRetryOptions
+          | undefined;
+
+        if (
+          meta?.updateType === 'put' &&
+          retryOptions?.initialResource &&
+          isResourceVersionConflict(httpError)
+        ) {
+          // 409 恢复是 PUT 更新的补偿逻辑；patch/create/delete 仍保持原来的失败语义。
+          try {
+            const data = await retryResourceVersionConflict<TData>({
+              error: httpError,
+              resource: variables as unknown as Unstructured,
+              initialResource: retryOptions.initialResource,
+              conflictMessage: retryOptions.conflictMessage,
+              getLatestResource: async () => {
+                // 一次性 GET 最新资源，不走 GlobalStore 的 listWatch/cache，避免创建额外 watch 连接。
+                return sdk.getOne({
+                  ...(variables as unknown as Unstructured),
+                  apiVersion: getApiVersion(meta?.resourceBasePath),
+                  kind: meta?.kind,
+                });
+              },
+              apply,
+            });
+
+            return {
+              data,
+            };
+          } catch (retryError) {
+            throw isHttpError(retryError)
+              ? retryError
+              : transformHttpError(retryError);
+          }
+        }
+
         throw httpError;
       }
     },

--- a/src/data-provider/resource-version-conflict-retry.ts
+++ b/src/data-provider/resource-version-conflict-retry.ts
@@ -1,0 +1,95 @@
+import { BaseRecord, HttpError } from '@refinedev/core';
+import { cloneDeep, isEqual, unset } from 'lodash-es';
+import { Unstructured } from '../kube-api';
+
+export type ResourceVersionConflictRetryOptions = {
+  initialResource?: Unstructured;
+  conflictMessage?: string;
+};
+
+type RetryResourceVersionConflictParams<TData extends BaseRecord> = {
+  error: HttpError;
+  initialResource?: Unstructured;
+  conflictMessage?: string;
+  getLatestResource: () => Promise<Unstructured>;
+  apply: (resource: Unstructured) => Promise<TData>;
+  resource: Unstructured;
+};
+
+const DEFAULT_CONFLICT_MESSAGE =
+  'The current data is no longer up to date. Please close the form, reopen it, edit again, and submit.';
+
+export function isResourceVersionConflict(error: HttpError) {
+  return error.statusCode === 409;
+}
+
+export function normalizeResourceForConflictCompare(resource: Unstructured) {
+  const result = cloneDeep(resource) as Unstructured;
+
+  // 这些字段不需要加入冲突比较
+  unset(result, 'id');
+  unset(result, 'status');
+  unset(result, 'metadata.resourceVersion');
+  unset(result, 'metadata.managedFields');
+  unset(result, 'metadata.relations');
+  unset(result, 'metadata.finalizers');
+  unset(result, [
+    'metadata',
+    'annotations',
+    'kubectl.kubernetes.io/last-applied-configuration',
+  ]);
+
+  if (
+    result.metadata?.annotations &&
+    Object.keys(result.metadata.annotations).length === 0
+  ) {
+    unset(result, 'metadata.annotations');
+  }
+
+  return result;
+}
+
+export function isSameResourceExceptRuntimeFields(
+  initialResource: Unstructured,
+  latestResource: Unstructured
+) {
+  return isEqual(
+    normalizeResourceForConflictCompare(initialResource),
+    normalizeResourceForConflictCompare(latestResource)
+  );
+}
+
+export async function retryResourceVersionConflict<TData extends BaseRecord>({
+  error,
+  initialResource,
+  conflictMessage = DEFAULT_CONFLICT_MESSAGE,
+  getLatestResource,
+  apply,
+  resource,
+}: RetryResourceVersionConflictParams<TData>): Promise<TData> {
+  if (!isResourceVersionConflict(error) || !initialResource) {
+    throw error;
+  }
+
+  const latestResource = await getLatestResource();
+  const latestResourceVersion = latestResource.metadata?.resourceVersion;
+
+  // 只有服务端最新版本和编辑初始版本除运行时字段外完全一致时，才允许自动重试。
+  if (
+    !latestResourceVersion ||
+    !isSameResourceExceptRuntimeFields(initialResource, latestResource)
+  ) {
+    throw {
+      message: conflictMessage,
+      statusCode: 409,
+    } as HttpError;
+  }
+
+  const retryResource = cloneDeep(resource);
+  retryResource.metadata = retryResource.metadata || {};
+  // 把服务端最新的 resourceVersion 覆盖到用户要保存的版本，避免覆盖服务端真实变更。
+  (retryResource.metadata as Record<string, unknown>).resourceVersion =
+    latestResourceVersion;
+
+  return apply(retryResource);
+}

--- a/src/kube-api.ts
+++ b/src/kube-api.ts
@@ -809,6 +809,10 @@ export class KubeSdk {
     return deleted;
   }
 
+  public async getOne(spec: Unstructured): Promise<Unstructured> {
+    return this.read(cloneDeep(spec)) as Promise<Unstructured>;
+  }
+
   private async read(spec: K8sObject) {
     const url = await this.specUriPath(spec, 'read');
     const res = await ky


### PR DESCRIPTION
## 背景

Kubernetes 在 PUT 更新资源时会校验 `metadata.resourceVersion`。如果用户打开编辑表单后，服务端资源因为 status、managedFields 等运行时字段刷新导致 `resourceVersion` 前进，旧表单提交时就会收到 409 Conflict。

这类冲突不一定代表用户会覆盖服务端的真实业务变更：如果服务端最新资源和用户打开表单时的初始资源相比，除了运行时字段和 `resourceVersion` 以外完全一致，那么用户提交的数据可以安全地使用服务端最新 `resourceVersion` 重试一次。

## 方案

- 在 `dataProvider.update` 中新增 PUT 409 的安全恢复逻辑。
- 首次提交遇到 409 时，通过 `KubeSdk.getOne` 对目标资源发起一次性 GET 请求，直接获取服务端最新资源，不走 `GlobalStore` 的 listWatch/cache/dedup 机制。
- 比较编辑初始资源和服务端最新资源，忽略以下运行时字段：
  - `id`
  - `status`
  - `metadata.resourceVersion`
  - `metadata.managedFields`
  - `metadata.relations`
  - `metadata.finalizers`
  - `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`
- 如果比较结果一致，则只把用户提交资源里的 `metadata.resourceVersion` 替换为服务端最新版本，并自动重试一次。
- 如果存在 spec、labels、annotations 等真实差异，或者二次提交仍失败，则直接抛错，不继续循环重试。
- 无法安全重试时抛出带 `statusCode: 409` 的 `HttpError`，方便下游按冲突错误展示。
- 非 409、非 PUT、缺少初始资源的场景保持原行为。

## 测试

- `yarn jest __tests__/data-provider/resource-version-conflict-retry.spec.ts --runInBand`
- `yarn typings`
- `yarn lint`
